### PR TITLE
Don't parse all cookies by default

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,17 @@ require('load-environment');
 
 const Hapi = require('hapi');
 
-const server = new Hapi.Server();
+const server = new Hapi.Server({
+  connections: {
+    routes: {
+      state: {
+        parse: false,
+        failAction: 'ignore'
+      }
+    }
+  }
+});
+
 const accessControl = require('./modules/access-control');
 
 const JWT_PUBLIC = process.env.JWT_PUBLIC && process.env.JWT_PUBLIC.replace(/\\n/g, '\n');


### PR DESCRIPTION
Fixes an issue with unparsable `Slido.Privacy` cookie causing

```
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "Invalid cookie value"
}
```